### PR TITLE
add DT_UNKNOWN

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -190,6 +190,7 @@ pub const SIG_DFL: sighandler_t = 0 as sighandler_t;
 pub const SIG_IGN: sighandler_t = 1 as sighandler_t;
 pub const SIG_ERR: sighandler_t = !0 as sighandler_t;
 
+pub const DT_UNKNOWN: u8 = 0;
 pub const DT_FIFO: u8 = 1;
 pub const DT_CHR: u8 = 2;
 pub const DT_DIR: u8 = 4;


### PR DESCRIPTION
The `d_type` field of `struct dirent` can be `DT_UNKNOWN` if a filesystem doesn't support returning the file type in directory entries. Linux's readdir(3) man page, for example, says: "Currently, only some filesystems [...] have full support for returning the file type in d_type. All applications must properly handle a return of DT_UNKNOWN."